### PR TITLE
add missing timeout function declaration

### DIFF
--- a/Arduino/LEDstream_LPD8806/LEDstream_LPD8806.pde
+++ b/Arduino/LEDstream_LPD8806/LEDstream_LPD8806.pde
@@ -73,6 +73,10 @@ static uint8_t
 static const unsigned long serialTimeout = 15000; // 15 seconds
 static unsigned long       lastByteTime, lastAckTime;
 
+//declaring functions
+static boolean timeout(unsigned long t, int nLEDs);
+static void latch(int n);
+
 void setup() {
   byte c;
   int  i, p;


### PR DESCRIPTION
function declaration was missing.
error while compiling because of using function timeout before definition